### PR TITLE
Fix build on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ ENDIF(WIN32)
 
 FIND_PACKAGE(Boost 1.57 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 
+SET(PLATFORM_LIBRARIES)
+
 if( APPLE )
   # Apple Specific Options Here
   message( STATUS "Configuring ChainBase on OS X" )
@@ -38,6 +40,7 @@ else( APPLE )
   if ( FULL_STATIC_BUILD )
     set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
   endif ( FULL_STATIC_BUILD )
+  LIST( APPEND PLATFORM_LIBRARIES pthread )
 endif( APPLE )
 
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
@@ -63,7 +66,7 @@ endif()
 
 file(GLOB HEADERS "include/*.hpp")
 add_library( chainbase src/chainbase.cpp ${HEADERS} )
-target_link_libraries( chainbase  ${Boost_LIBRARIES} )
+target_link_libraries( chainbase  ${Boost_LIBRARIES} ${PLATFORM_LIBRARIES} )
 target_include_directories( chainbase PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"  ${Boost_INCLUDE_DIR} )
 
 add_subdirectory( test )

--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -104,7 +104,6 @@ namespace chainbase {
    {
       typedef oid<Derived> id_type;
       static const uint16_t type_id = TypeNumber;
-
    };
 
    /** this class is ment to be specified to enable lookup of index type by object type using
@@ -654,6 +653,7 @@ namespace chainbase {
          };
 
          void open( const bfs::path& dir, uint32_t write = read_only, uint64_t shared_file_size = 0 );
+         bool is_open()const;
          void close();
          void flush();
          void wipe( const bfs::path& dir );

--- a/src/chainbase.cpp
+++ b/src/chainbase.cpp
@@ -105,6 +105,11 @@ namespace chainbase {
       }
    }
 
+   bool database::is_open() const
+   {
+      return _segment && _meta && !_data_dir.empty();
+   }
+
    void database::flush() {
       if( _segment )
          _segment->flush();


### PR DESCRIPTION
Linux builds require linking against pthreads, which was not being
done. Add pthreads to libraries to link against on Linux.