### PR TITLE
Clear indexes on close()

### DIFF
--- a/src/chainbase.cpp
+++ b/src/chainbase.cpp
@@ -121,6 +121,8 @@ namespace chainbase {
    {
       _segment.reset();
       _meta.reset();
+      _index_list.clear();
+      _index_map.clear();
       _data_dir = bfs::path();
    }
 


### PR DESCRIPTION
Indexes were not being cleared on close(), meaning the database was not
properly closed and could not be safely reopened. Fixed.